### PR TITLE
Add $template part shortcode argument.

### DIFF
--- a/simple-user-listing.php
+++ b/simple-user-listing.php
@@ -190,7 +190,7 @@ if ( ! class_exists( 'Simple_User_Listing' ) ) {
 				'count_total' => true,
 				'taxonomy' => '',
 				'terms' => '',
-				'template' => 'content',
+				'template' => 'author',
 			);
 			
 			$atts = wp_parse_args( $atts, $defaults );
@@ -296,7 +296,7 @@ if ( ! class_exists( 'Simple_User_Listing' ) ) {
 				// loop through each author
 				foreach( $users as $user ){
 					$user->counter = ++$i;
-					sul_get_template_part( $atts['template'], 'author' );
+					sul_get_template_part( 'content', $atts['template'] );
 				}
 			} else {
 				sul_get_template_part( 'none', 'author' );

--- a/simple-user-listing.php
+++ b/simple-user-listing.php
@@ -189,7 +189,8 @@ if ( ! class_exists( 'Simple_User_Listing' ) ) {
 				'meta_type' => 'CHAR',
 				'count_total' => true,
 				'taxonomy' => '',
-				'terms' => ''
+				'terms' => '',
+				'template' => 'content',
 			);
 			
 			$atts = wp_parse_args( $atts, $defaults );
@@ -295,7 +296,7 @@ if ( ! class_exists( 'Simple_User_Listing' ) ) {
 				// loop through each author
 				foreach( $users as $user ){
 					$user->counter = ++$i;
-					sul_get_template_part( 'content', 'author' );
+					sul_get_template_part( $atts['template'], 'author' );
 				}
 			} else {
 				sul_get_template_part( 'none', 'author' );


### PR DESCRIPTION
Added a shortcode argument as $template, which is the name of an additional template part - located in yourtheme/simple-user-listing/slug-author.php. The name in $template must match the "slug" part of the filename. If no template is specified, it defaults to content-author.php.

Example: [userlist template="members"] with a corresponding file of yourtheme/simple-user-listing/members-author.php