### PR TITLE
Add a filter before the loop to display users.

### DIFF
--- a/simple-user-listing.php
+++ b/simple-user-listing.php
@@ -287,6 +287,9 @@ if ( ! class_exists( 'Simple_User_Listing' ) ) {
 			// The authors object.
 			$users = $sul_users->get_results();
 
+			// Filter users just before the display loop
+			$users = apply_filters( 'simple_user_listing_users', $users, $atts['query_id']);
+
 			// before the user listing loop
 			do_action( 'simple_user_listing_before_loop', $atts['query_id'], $atts );
 


### PR DESCRIPTION
This can be useful to manage very uncommon filters that are not doable with WP_User_Query like sorting users per role (with an uncommon role order).
Ex : Display first the President, then Vice-Presdient, then etc...